### PR TITLE
Add surf API service with health and surf endpoints

### DIFF
--- a/services/surf-api/Dockerfile
+++ b/services/surf-api/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.22 AS build
+WORKDIR /src
+COPY go.mod go.sum .
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o surf-api
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=build /src/surf-api /surf-api
+EXPOSE 8080
+ENTRYPOINT ["/surf-api"]

--- a/services/surf-api/cmd/surf-api/main.go
+++ b/services/surf-api/cmd/surf-api/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+    "log"
+    "net/http"
+
+    "github.com/NomadWave/surf-api"
+)
+
+func main() {
+    srv := surfapi.NewServer(surfapi.StaticReporter{})
+    log.Fatal(http.ListenAndServe(":8080", srv))
+}
+

--- a/services/surf-api/go.mod
+++ b/services/surf-api/go.mod
@@ -1,0 +1,3 @@
+module github.com/NomadWave/surf-api
+
+go 1.22

--- a/services/surf-api/server.go
+++ b/services/surf-api/server.go
@@ -1,0 +1,50 @@
+package surfapi
+
+import (
+    "encoding/json"
+    "net/http"
+)
+
+// Reporter provides surf condition data.
+type Reporter interface {
+    Report() string
+}
+
+// Server handles HTTP requests.
+type Server struct {
+    reporter Reporter
+    mux      *http.ServeMux
+}
+
+// NewServer wires dependencies and returns a Server.
+func NewServer(r Reporter) *Server {
+    s := &Server{reporter: r, mux: http.NewServeMux()}
+    s.routes()
+    return s
+}
+
+// ServeHTTP implements http.Handler.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    s.mux.ServeHTTP(w, r)
+}
+
+func (s *Server) routes() {
+    s.mux.HandleFunc("/healthz", s.healthHandler)
+    s.mux.HandleFunc("/v1/surf", s.surfHandler)
+}
+
+func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+    _, _ = w.Write([]byte("ok"))
+}
+
+func (s *Server) surfHandler(w http.ResponseWriter, r *http.Request) {
+    resp := map[string]string{"report": s.reporter.Report()}
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(resp)
+}
+
+// StaticReporter is a basic Reporter implementation.
+type StaticReporter struct{}
+
+func (StaticReporter) Report() string { return "flat" }

--- a/services/surf-api/server_test.go
+++ b/services/surf-api/server_test.go
@@ -1,0 +1,48 @@
+package surfapi
+
+import (
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+type stubReporter struct{ msg string }
+
+func (s stubReporter) Report() string { return s.msg }
+
+func TestHealthzHandler(t *testing.T) {
+    srv := NewServer(stubReporter{})
+    req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+    rr := httptest.NewRecorder()
+    srv.ServeHTTP(rr, req)
+
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected status 200, got %d", rr.Code)
+    }
+    if body := rr.Body.String(); body != "ok" {
+        t.Fatalf("unexpected body %q", body)
+    }
+}
+
+func TestSurfHandlerUsesReporter(t *testing.T) {
+    expected := "great waves"
+    srv := NewServer(stubReporter{msg: expected})
+
+    req := httptest.NewRequest(http.MethodGet, "/v1/surf", nil)
+    rr := httptest.NewRecorder()
+    srv.ServeHTTP(rr, req)
+
+    if rr.Code != http.StatusOK {
+        t.Fatalf("expected status 200, got %d", rr.Code)
+    }
+
+    var resp map[string]string
+    if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("invalid JSON: %v", err)
+    }
+    if resp["report"] != expected {
+        t.Fatalf("expected report %q, got %q", expected, resp["report"])
+    }
+}
+


### PR DESCRIPTION
## Summary
- scaffold surf-api Go module with health and surf endpoints
- add unit tests for handlers and dependency injection
- include Dockerfile for reproducible builds

## Testing
- `go test ./...`
