### PR TITLE
Add job specs for NATS JetStream and ClickHouse

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -1,0 +1,16 @@
+# Data Pipeline
+
+The NomadWave data pipeline ingests raw surf and weather events, buffers them in NATS JetStream and persists curated observations in ClickHouse.
+
+## Flow
+1. **Producers** publish buoy and weather JSON to JetStream.
+2. **Ingest workers** consume the stream and batch insert into ClickHouse.
+3. **API** queries ClickHouse for recent conditions.
+
+## Retention Policies
+- **NATS JetStream**
+  - Messages retained for up to **7 days** or **2 GB**, whichever comes first.
+  - Backed by a host volume to survive client restarts.
+- **ClickHouse**
+  - `surf.observations` table uses a TTL to drop rows after **30 days**.
+  - Older snapshots can be archived to object storage for long‑term analysis.

--- a/jobs/clickhouse.nomad.hcl
+++ b/jobs/clickhouse.nomad.hcl
@@ -1,0 +1,66 @@
+job "clickhouse" {
+  datacenters = ["dc1"]
+
+  group "clickhouse" {
+    count = 1
+
+    volume "ch-data" {
+      type      = "host"
+      read_only = false
+      source    = "clickhouse"
+    }
+
+    network {
+      port "tcp" {
+        to = 9000
+      }
+      port "http" {
+        to = 8123
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image   = "clickhouse/clickhouse-server:23-alpine"
+        ports   = ["tcp", "http"]
+        volumes = ["local:/docker-entrypoint-initdb.d"]
+      }
+
+      template {
+        destination = "local/schema.sql"
+        data = <<EOT
+CREATE DATABASE IF NOT EXISTS surf;
+
+CREATE TABLE IF NOT EXISTS surf.observations (
+  station_id String,
+  ts DateTime,
+  wave_height Float32,
+  wave_period Float32,
+  wind_speed Float32,
+  wind_direction UInt16
+) ENGINE = MergeTree()
+ORDER BY (station_id, ts)
+TTL ts + INTERVAL 30 DAY;
+EOT
+      }
+
+      volume_mount {
+        volume      = "ch-data"
+        destination = "/var/lib/clickhouse"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+
+      service {
+        name = "clickhouse"
+        port = "tcp"
+        tags = ["db"]
+      }
+    }
+  }
+}

--- a/jobs/nats.nomad.hcl
+++ b/jobs/nats.nomad.hcl
@@ -1,0 +1,60 @@
+job "nats" {
+  datacenters = ["dc1"]
+
+  group "nats" {
+    count = 1
+
+    volume "nats-data" {
+      type      = "host"
+      read_only = false
+      source    = "nats"
+    }
+
+    network {
+      port "nats" {
+        to = 4222
+      }
+      port "http" {
+        to = 8222
+      }
+    }
+
+    task "server" {
+      driver = "docker"
+
+      config {
+        image = "nats:2.10-alpine"
+        ports = ["nats", "http"]
+        args  = ["-c", "${NOMAD_ALLOC_DIR}/local/nats.conf"]
+      }
+
+      template {
+        destination = "local/nats.conf"
+        data = <<EOT
+port: 4222
+http: 8222
+jetstream {
+  store_dir: /data/jetstream
+  max_mem: 256MB
+  max_file: 2GB
+}
+EOT
+      }
+
+      volume_mount {
+        volume      = "nats-data"
+        destination = "/data"
+      }
+
+      resources {
+        cpu    = 200
+        memory = 128
+      }
+
+      service {
+        name = "nats"
+        port = "nats"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Nomad job for NATS JetStream with persistent storage
- add ClickHouse job and surf observation schema
- document data pipeline retention policies

## Testing
- `nomad job validate jobs/nats.nomad.hcl`
- `nomad job validate jobs/clickhouse.nomad.hcl`

