### PR TITLE
Add Nomad jobs and Consul service splitter

### DIFF
--- a/jobs/consul/service-splitter.hcl
+++ b/jobs/consul/service-splitter.hcl
@@ -1,0 +1,23 @@
+# Consul service-splitter for surf-api progressive rollouts.
+# Start with 5% of traffic directed to the canary subset and
+# update the weights to 50% and 100% as the deployment proceeds.
+
+Kind = "service-splitter"
+Name = "surf-api"
+
+# Stage 1: 5% canary
+Splits = [
+  { Weight = 95, Service = "surf-api", ServiceSubset = "v1" },
+  { Weight = 5,  Service = "surf-api", ServiceSubset = "v2" }
+]
+
+# Stage 2: adjust weights to 50/50
+# Splits = [
+#   { Weight = 50, Service = "surf-api", ServiceSubset = "v1" },
+#   { Weight = 50, Service = "surf-api", ServiceSubset = "v2" }
+# ]
+
+# Stage 3: 100% to v2
+# Splits = [
+#   { Weight = 100, Service = "surf-api", ServiceSubset = "v2" }
+# ]

--- a/jobs/ingest.nomad.hcl
+++ b/jobs/ingest.nomad.hcl
@@ -1,0 +1,38 @@
+job "ingest" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  update {
+    stagger  = "30s"
+    strategy = "canary"
+  }
+
+  group "ingest" {
+    network {
+      port "http" {
+        to = 9000
+      }
+    }
+
+    service {
+      name = "ingest"
+      port = "http"
+
+      check {
+        name     = "ingest-health"
+        type     = "http"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "ingest" {
+      driver = "exec-fc"
+
+      config {
+        command = "/bin/ingest"
+      }
+    }
+  }
+}

--- a/jobs/surf-api.nomad.hcl
+++ b/jobs/surf-api.nomad.hcl
@@ -1,0 +1,38 @@
+job "surf-api" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  update {
+    stagger  = "30s"
+    strategy = "canary"
+  }
+
+  group "surf-api" {
+    network {
+      port "http" {
+        to = 8080
+      }
+    }
+
+    service {
+      name = "surf-api"
+      port = "http"
+
+      check {
+        name     = "surf-api-health"
+        type     = "http"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
+    task "surf-api" {
+      driver = "exec-fc"
+
+      config {
+        command = "/bin/surf-api"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add surf-api Nomad job with canary strategy and Consul service
- add ingest Nomad job with canary strategy and Consul service
- include Consul service-splitter config for progressive rollout

## Testing
- `nomad job validate jobs/surf-api.nomad.hcl` *(fails: Unsupported argument; An argument named "strategy" is not expected here.)*
- `nomad job validate jobs/ingest.nomad.hcl` *(fails: Unsupported argument; An argument named "strategy" is not expected here.)*
- `consul validate jobs/consul/service-splitter.hcl` *(fails: invalid config key Kind; invalid config key Name; invalid config key Splits)*

