### PR TITLE
Add AWS core Terraform modules for Nomad/Consul cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Terraform local files
+**/.terraform/
+*.tfstate
+*.tfstate.*
+terraform.tfvars

--- a/terraform/aws-core/.terraform.lock.hcl
+++ b/terraform/aws-core/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/aws-core/main.tf
+++ b/terraform/aws-core/main.tf
@@ -1,0 +1,30 @@
+module "vpc" {
+  source = "./modules/vpc"
+  name   = var.project
+  cidr   = var.vpc_cidr
+}
+
+module "subnets" {
+  source          = "./modules/subnets"
+  name            = var.project
+  vpc_id          = module.vpc.id
+  azs             = var.azs
+  public_subnets  = var.public_subnets
+  private_subnets = var.private_subnets
+}
+
+module "security_groups" {
+  source        = "./modules/security-groups"
+  name          = var.project
+  vpc_id        = module.vpc.id
+  ingress_cidrs = var.ingress_cidrs
+}
+
+module "nomad_consul" {
+  source            = "./modules/nomad-consul-asg"
+  name              = var.project
+  subnet_ids        = module.subnets.private_subnet_ids
+  security_group_id = module.security_groups.id
+  desired_capacity  = var.server_count
+  zone_name         = var.zone_name
+}

--- a/terraform/aws-core/modules/nomad-consul-asg/main.tf
+++ b/terraform/aws-core/modules/nomad-consul-asg/main.tf
@@ -1,0 +1,70 @@
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-kernel-6.1-arm64"]
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name = "${var.name}-nomad-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = "${var.name}-nomad-profile"
+  role = aws_iam_role.this.name
+}
+
+resource "aws_launch_template" "this" {
+  name_prefix   = "${var.name}-nomad-"
+  image_id      = data.aws_ami.al2023.id
+  instance_type = "t4g.micro"
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.this.name
+  }
+
+  vpc_security_group_ids = [var.security_group_id]
+}
+
+resource "aws_autoscaling_group" "this" {
+  name                = "${var.name}-nomad-asg"
+  max_size            = var.desired_capacity
+  min_size            = var.desired_capacity
+  desired_capacity    = var.desired_capacity
+  vpc_zone_identifier = var.subnet_ids
+
+  launch_template {
+    id      = aws_launch_template.this.id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${var.name}-nomad"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_route53_zone" "this" {
+  name = var.zone_name
+}
+
+data "aws_instances" "nomad" {
+  depends_on = [aws_autoscaling_group.this]
+  filter {
+    name   = "tag:Name"
+    values = ["${var.name}-nomad"]
+  }
+  instance_state_names = ["running"]
+}

--- a/terraform/aws-core/modules/nomad-consul-asg/outputs.tf
+++ b/terraform/aws-core/modules/nomad-consul-asg/outputs.tf
@@ -1,0 +1,11 @@
+output "private_ips" {
+  value = data.aws_instances.nomad.private_ips
+}
+
+output "zone_id" {
+  value = aws_route53_zone.this.zone_id
+}
+
+output "iam_role_arn" {
+  value = aws_iam_role.this.arn
+}

--- a/terraform/aws-core/modules/nomad-consul-asg/variables.tf
+++ b/terraform/aws-core/modules/nomad-consul-asg/variables.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  description = "Name prefix for resources"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for the ASG"
+  type        = list(string)
+}
+
+variable "security_group_id" {
+  description = "Security group ID for instances"
+  type        = string
+}
+
+variable "desired_capacity" {
+  description = "Number of Nomad/Consul server instances"
+  type        = number
+}
+
+variable "zone_name" {
+  description = "Route53 zone name"
+  type        = string
+}

--- a/terraform/aws-core/modules/security-groups/main.tf
+++ b/terraform/aws-core/modules/security-groups/main.tf
@@ -1,0 +1,40 @@
+resource "aws_security_group" "nomad" {
+  name        = "${var.name}-nomad-sg"
+  description = "Security group for Nomad and Consul servers"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
+  }
+
+  ingress {
+    description = "Nomad RPC"
+    from_port   = 4646
+    to_port     = 4648
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
+  }
+
+  ingress {
+    description = "Consul"
+    from_port   = 8500
+    to_port     = 8600
+    protocol    = "tcp"
+    cidr_blocks = var.ingress_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name}-nomad"
+  }
+}

--- a/terraform/aws-core/modules/security-groups/outputs.tf
+++ b/terraform/aws-core/modules/security-groups/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = aws_security_group.nomad.id
+}

--- a/terraform/aws-core/modules/security-groups/variables.tf
+++ b/terraform/aws-core/modules/security-groups/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  description = "Security group name prefix"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "ingress_cidrs" {
+  description = "CIDR blocks allowed to access Nomad/Consul"
+  type        = list(string)
+}

--- a/terraform/aws-core/modules/subnets/main.tf
+++ b/terraform/aws-core/modules/subnets/main.tf
@@ -1,0 +1,20 @@
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnets)
+  vpc_id                  = var.vpc_id
+  cidr_block              = var.public_subnets[count.index]
+  availability_zone       = var.azs[count.index]
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "${var.name}-public-${count.index}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnets)
+  vpc_id            = var.vpc_id
+  cidr_block        = var.private_subnets[count.index]
+  availability_zone = var.azs[count.index]
+  tags = {
+    Name = "${var.name}-private-${count.index}"
+  }
+}

--- a/terraform/aws-core/modules/subnets/outputs.tf
+++ b/terraform/aws-core/modules/subnets/outputs.tf
@@ -1,0 +1,7 @@
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}

--- a/terraform/aws-core/modules/subnets/variables.tf
+++ b/terraform/aws-core/modules/subnets/variables.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  description = "Subnet name prefix"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "azs" {
+  description = "Availability zones"
+  type        = list(string)
+}
+
+variable "public_subnets" {
+  description = "Public subnet CIDRs"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "Private subnet CIDRs"
+  type        = list(string)
+}

--- a/terraform/aws-core/modules/vpc/main.tf
+++ b/terraform/aws-core/modules/vpc/main.tf
@@ -1,0 +1,8 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags = {
+    Name = var.name
+  }
+}

--- a/terraform/aws-core/modules/vpc/outputs.tf
+++ b/terraform/aws-core/modules/vpc/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = aws_vpc.this.id
+}

--- a/terraform/aws-core/modules/vpc/variables.tf
+++ b/terraform/aws-core/modules/vpc/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  description = "VPC name"
+  type        = string
+}
+
+variable "cidr" {
+  description = "VPC CIDR block"
+  type        = string
+}

--- a/terraform/aws-core/outputs.tf
+++ b/terraform/aws-core/outputs.tf
@@ -1,0 +1,14 @@
+output "nomad_server_private_ips" {
+  description = "Private IPs of Nomad/Consul servers"
+  value       = module.nomad_consul.private_ips
+}
+
+output "route53_zone_id" {
+  description = "Route53 hosted zone ID"
+  value       = module.nomad_consul.zone_id
+}
+
+output "nomad_server_role_arn" {
+  description = "IAM role ARN for Nomad/Consul servers"
+  value       = module.nomad_consul.iam_role_arn
+}

--- a/terraform/aws-core/provider.tf
+++ b/terraform/aws-core/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.7"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/aws-core/terraform.tfvars.example
+++ b/terraform/aws-core/terraform.tfvars.example
@@ -1,0 +1,9 @@
+region          = "ap-southeast-2"
+project         = "nomadwave"
+vpc_cidr        = "10.0.0.0/16"
+azs             = ["ap-southeast-2a", "ap-southeast-2b"]
+public_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]
+private_subnets = ["10.0.101.0/24", "10.0.102.0/24"]
+ingress_cidrs   = ["0.0.0.0/0"]
+server_count    = 3
+zone_name       = "nomadwave.example.com"

--- a/terraform/aws-core/variables.tf
+++ b/terraform/aws-core/variables.tf
@@ -1,0 +1,44 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "project" {
+  description = "Project name prefix"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+}
+
+variable "azs" {
+  description = "Availability zones"
+  type        = list(string)
+}
+
+variable "public_subnets" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "CIDR blocks for private subnets"
+  type        = list(string)
+}
+
+variable "ingress_cidrs" {
+  description = "CIDR blocks allowed for ingress"
+  type        = list(string)
+}
+
+variable "server_count" {
+  description = "Number of Nomad/Consul servers"
+  type        = number
+}
+
+variable "zone_name" {
+  description = "Route53 hosted zone name"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- scaffold AWS core Terraform configuration for VPC, subnets, security groups, and Nomad/Consul server ASG
- expose outputs for server IPs, Route53 zone, and instance IAM role
- provide terraform.tfvars.example with default parameters

## Testing
- `terraform init -input=false`
- `terraform validate`


