### PR TITLE
Add Consul configs and mTLS documentation

### DIFF
--- a/consul/intentions/clickhouse.hcl
+++ b/consul/intentions/clickhouse.hcl
@@ -1,0 +1,8 @@
+kind = "service-intentions"
+name = "clickhouse"
+sources = [
+  {
+    name   = "surf-api"
+    action = "allow"
+  }
+]

--- a/consul/intentions/surf-api.hcl
+++ b/consul/intentions/surf-api.hcl
@@ -1,0 +1,8 @@
+kind = "service-intentions"
+name = "surf-api"
+sources = [
+  {
+    name   = "clickhouse"
+    action = "allow"
+  }
+]

--- a/consul/service-defaults/clickhouse.hcl
+++ b/consul/service-defaults/clickhouse.hcl
@@ -1,0 +1,3 @@
+kind = "service-defaults"
+name = "clickhouse"
+protocol = "http"

--- a/consul/service-defaults/surf-api.hcl
+++ b/consul/service-defaults/surf-api.hcl
@@ -1,0 +1,3 @@
+kind = "service-defaults"
+name = "surf-api"
+protocol = "http"

--- a/consul/service-resolvers/clickhouse.hcl
+++ b/consul/service-resolvers/clickhouse.hcl
@@ -1,0 +1,3 @@
+kind = "service-resolver"
+name = "clickhouse"
+connect_timeout = "5s"

--- a/consul/service-resolvers/surf-api.hcl
+++ b/consul/service-resolvers/surf-api.hcl
@@ -1,0 +1,3 @@
+kind = "service-resolver"
+name = "surf-api"
+connect_timeout = "5s"

--- a/docs/consul.md
+++ b/docs/consul.md
@@ -1,0 +1,36 @@
+# Consul Service Mesh
+
+## mTLS Setup
+
+Consul's Connect service mesh secures service-to-service communication with mutual TLS (mTLS).
+
+1. Enable Connect on every agent:
+   ```hcl
+   connect {
+     enabled = true
+   }
+   ```
+2. Bootstrap the built-in certificate authority:
+   ```bash
+   consul connect ca bootstrap
+   ```
+   The command creates a root certificate and private key in the server's data directory.
+3. Distribute the CA configuration to all agents. Each agent automatically requests and rotates leaf certificates for its services.
+4. Register services with Connect sidecars or transparent proxies so that all traffic is encrypted.
+
+## Certificate Rotation
+
+Consul rotates leaf certificates automatically before they expire. Rotate the root CA or force leaf rotation when required:
+
+- Rotate the root certificate:
+  ```bash
+  consul connect ca rotate
+  ```
+  Consul generates a new root certificate and creates a cross-signed intermediate so existing certificates remain valid during the transition.
+- Force leaf certificate rotation:
+  ```bash
+  consul connect ca leaf rotate
+  ```
+  Use a short `leaf_cert_ttl` in the agent configuration (e.g., `72h`) to ensure regular rotation.
+
+After a root rotation completes and all leaf certificates are renewed, remove the old root certificate from the system.


### PR DESCRIPTION
## Summary
- add Consul service-defaults, service-resolvers and L7 intentions for `surf-api` and `clickhouse`
- document Consul mTLS setup and certificate rotation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*
