### PR TITLE
Add GitLab CI pipeline and docs

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -1,0 +1,42 @@
+stages:
+  - test
+  - scan
+  - build
+  - deploy
+
+variables:
+  IMAGE_REGISTRY: registry.example.com/nomadwave
+  IMAGE_TAG: "$CI_COMMIT_SHA"
+
+test:
+  stage: test
+  image: golang:1.21
+  script:
+    - go test ./...
+
+scan:
+  stage: scan
+  image:
+    name: aquasec/trivy:latest
+    entrypoint: [""]
+  script:
+    - trivy fs --exit-code 1 .
+
+build:
+  stage: build
+  image: docker:24.0
+  services:
+    - docker:dind
+  variables:
+    DOCKER_TLS_CERTDIR: ""
+  script:
+    - docker build -t "$IMAGE_REGISTRY:$IMAGE_TAG" .
+    - docker push "$IMAGE_REGISTRY:$IMAGE_TAG"
+
+deploy:
+  stage: deploy
+  image: hashicorp/nomad:latest
+  script:
+    - nomad job run -replace job.hcl
+  only:
+    - main

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,13 @@
+# CI Configuration
+
+This repository uses GitLab CI to test, scan, build, and deploy the application.
+
+## Protected variables
+
+Define the following variables in **Settings > CI/CD > Variables** and mark them as *protected* so that they are only available on protected branches and tags.
+
+- `IMAGE_REGISTRY` – Docker registry where images are pushed.
+- `NOMAD_ADDR` – URL of the Nomad API endpoint.
+- `NOMAD_TOKEN` – Token with permissions to update the Nomad job.
+
+GitLab automatically provides `CI_COMMIT_SHA`, which is used as the image tag.


### PR DESCRIPTION
## Summary
- add GitLab CI pipeline with test, scan, build, and deploy stages
- tag Docker images with commit SHA and configurable registry
- document required protected variables for CI

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module)*

