### PR TITLE
Add observability jobs and dashboard

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,21 @@
+# Observability
+
+NomadWave's observability stack is composed of VictoriaMetrics for metrics storage, Grafana for dashboards, and Loki for log aggregation.
+
+## Scrape Targets
+
+VictoriaMetrics scrapes the following targets:
+
+- Nomad metrics gateway on `:4646`
+- Application metrics exposed by `surf-api`
+- Carbon plugin metrics including `co2_per_request`
+- Loki and Grafana internal `/metrics` endpoints
+
+## Alerting Rules
+
+The cluster defines two primary alerting rules:
+
+1. **High CO₂ per Request** – triggers when `co2_per_request > 1.0` for 5 minutes.
+2. **Request Latency** – triggers when `http_request_duration_ms` average exceeds 150 ms for 5 minutes.
+
+Alerts are routed to the Nomad autoscaler which can drain high‑carbon nodes.

--- a/grafana_dashboards/carbon_latency.json
+++ b/grafana_dashboards/carbon_latency.json
@@ -1,0 +1,30 @@
+{
+  "id": null,
+  "title": "Carbon & Latency",
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "version": 0,
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "API Latency (ms)",
+      "datasource": "VictoriaMetrics",
+      "targets": [
+        { "expr": "avg(rate(http_request_duration_ms_sum[1m]))" }
+      ],
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}
+    },
+    {
+      "type": "graph",
+      "title": "CO2 per Request (g)",
+      "datasource": "VictoriaMetrics",
+      "targets": [
+        { "expr": "avg(co2_per_request)" }
+      ],
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0}
+    }
+  ]
+}

--- a/jobs/observability/grafana.nomad.hcl
+++ b/jobs/observability/grafana.nomad.hcl
@@ -1,0 +1,39 @@
+job "grafana" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "grafana" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 3000
+      }
+    }
+
+    task "grafana" {
+      driver = "docker"
+
+      config {
+        image = "grafana/grafana"
+        ports = ["http"]
+      }
+
+      env {
+        GF_SECURITY_ADMIN_USER     = "admin"
+        GF_SECURITY_ADMIN_PASSWORD = "admin"
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+
+      service {
+        name = "grafana"
+        port = "http"
+        tags = ["dashboard"]
+      }
+    }
+  }
+}

--- a/jobs/observability/loki.nomad.hcl
+++ b/jobs/observability/loki.nomad.hcl
@@ -1,0 +1,35 @@
+job "loki" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "loki" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 3100
+      }
+    }
+
+    task "loki" {
+      driver = "docker"
+
+      config {
+        image = "grafana/loki"
+        args  = ["-config.file=/etc/loki/local-config.yaml"]
+        ports = ["http"]
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+
+      service {
+        name = "loki"
+        port = "http"
+        tags = ["logs"]
+      }
+    }
+  }
+}

--- a/jobs/observability/victoriametrics.nomad.hcl
+++ b/jobs/observability/victoriametrics.nomad.hcl
@@ -1,0 +1,35 @@
+job "victoriametrics" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "vm" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 8428
+      }
+    }
+
+    task "victoriametrics" {
+      driver = "docker"
+
+      config {
+        image = "victoriametrics/victoria-metrics"
+        ports = ["http"]
+        args  = ["--selfScrapeInterval=30s"]
+      }
+
+      resources {
+        cpu    = 500
+        memory = 512
+      }
+
+      service {
+        name = "victoriametrics"
+        port = "http"
+        tags = ["metrics"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Nomad job specs for VictoriaMetrics, Grafana, and Loki
- include carbon and latency Grafana dashboard JSON
- document scrape targets and alerting rules

## Testing
- `pytest`


