### PR TITLE
Add Vault policies and Nomad Vault Agent example

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,29 @@
+# Security
+
+## Boundary Ephemeral Exec Access
+
+Use [HashiCorp Boundary](https://www.boundaryproject.io/) to provide just-in-time shell
+access to Nomad workloads.  Boundary brokers temporary credentials and terminates
+the session when finished, limiting exposure of long-lived SSH keys.
+
+### Example Target Configuration
+
+```hcl
+target "nomad-shell" {
+  type              = "ssh"
+  description       = "Ephemeral shell for Nomad allocations"
+  scope_id          = "<project-scope-id>"
+  default_port      = 22
+  worker_filter     = "\"nomad\" in \"${boundary.worker.tags}\""
+  session_max_seconds = 600
+}
+```
+
+An operator can then open a session:
+
+```bash
+boundary connect ssh -target-id <target-id> -- -l ubuntu
+```
+
+Boundary issues an ephemeral credential and revokes it automatically when the
+session ends.

--- a/nomad/jobs/db-vault-agent.nomad
+++ b/nomad/jobs/db-vault-agent.nomad
@@ -1,0 +1,69 @@
+job "db-example" {
+  datacenters = ["dc1"]
+
+  group "app" {
+    task "api" {
+      driver = "docker"
+      config {
+        image = "myorg/api:latest"
+      }
+
+      volume_mount {
+        volume      = "secrets"
+        destination = "/secrets"
+      }
+
+      env {
+        DB_CREDS_FILE = "/secrets/db-creds.env"
+      }
+    }
+
+    task "vault-agent" {
+      driver = "docker"
+      config {
+        image   = "hashicorp/vault:1.13"
+        command = "agent"
+        args    = ["-config=/local/agent.hcl"]
+      }
+
+      volume_mount {
+        volume      = "secrets"
+        destination = "/secrets"
+      }
+
+      template {
+        destination = "local/agent.hcl"
+        data = <<EOT
+auto_auth {
+  method "approle" {
+    config = {
+      role_id_file_path   = "/secrets/role_id"
+      secret_id_file_path = "/secrets/secret_id"
+    }
+  }
+  sink "file" {
+    config = {
+      path = "/secrets/token"
+    }
+  }
+}
+
+template {
+  contents = <<EOH
+{{ with secret "database/creds/app" }}
+DB_USERNAME={{ .Data.username }}
+DB_PASSWORD={{ .Data.password }}
+{{ end }}
+EOH
+  destination = "/secrets/db-creds.env"
+}
+EOT
+      }
+    }
+
+    volume "secrets" {
+      type      = "tmpfs"
+      read_only = false
+    }
+  }
+}

--- a/security/vault/policies/web.hcl
+++ b/security/vault/policies/web.hcl
@@ -1,0 +1,7 @@
+path "database/creds/web" {
+  capabilities = ["read"]
+}
+
+path "kv/data/web/*" {
+  capabilities = ["read"]
+}

--- a/security/vault/policies/worker.hcl
+++ b/security/vault/policies/worker.hcl
@@ -1,0 +1,7 @@
+path "database/creds/worker" {
+  capabilities = ["read"]
+}
+
+path "kv/data/worker/*" {
+  capabilities = ["read"]
+}

--- a/security/vault/roles/web.hcl
+++ b/security/vault/roles/web.hcl
@@ -1,0 +1,4 @@
+# AppRole for web service
+token_policies = ["web"]
+token_ttl      = "1h"
+token_max_ttl  = "4h"

--- a/security/vault/roles/worker.hcl
+++ b/security/vault/roles/worker.hcl
@@ -1,0 +1,4 @@
+# AppRole for worker service
+token_policies = ["worker"]
+token_ttl      = "1h"
+token_max_ttl  = "4h"


### PR DESCRIPTION
## Summary
- Define example Vault policies and AppRole configs for web and worker services
- Add Nomad job snippet demonstrating Vault Agent sidecar for dynamic DB credentials
- Document Boundary setup for ephemeral exec access

## Testing
- `npm test` *(fails: Could not read package.json)*

